### PR TITLE
libcv-dev package does not contain opencv.pc

### DIFF
--- a/setupenv.sh
+++ b/setupenv.sh
@@ -6,7 +6,7 @@ cd ..
 
 sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/pcl
 sudo apt-get update
-sudo apt-get -y install libxml2-dev libsdl-dev libglew-dev libcv-dev libcvaux-dev libhighgui-dev libqhull-dev freeglut3-dev libxmu-dev python-dev libboost-python-dev ipython openrtm-aist-python libpcl-all
+sudo apt-get -y install libxml2-dev libsdl-dev libglew-dev libopencv-dev libcvaux-dev libhighgui-dev libqhull-dev freeglut3-dev libxmu-dev python-dev libboost-python-dev ipython openrtm-aist-python libpcl-all
 sudo apt-get -y install libyaml-dev libncurses5-dev
 
 cd $SRC_DIR/choreonoid/misc/script


### PR DESCRIPTION
It makes a not-found error when using pkg-config (hrpsys-base ..).
libopencv-dev has that file.

http://stackoverflow.com/questions/15320267/package-opencv-was-not-found-in-the-pkg-config-search-path
